### PR TITLE
Fix DynamoDB bean conflicts with service-specific qualifiers

### DIFF
--- a/src/main/kotlin/com/healthcare/medication/catalog/infrastructure/config/DynamoDbConfig.kt
+++ b/src/main/kotlin/com/healthcare/medication/catalog/infrastructure/config/DynamoDbConfig.kt
@@ -15,6 +15,7 @@ class DynamoDbConfig {
     
     @Bean
     @Singleton
+    @MedicationCatalogDynamoDb
     fun dynamoDbClient(): DynamoDbClient {
         return DynamoDbClient.builder()
             .region(Region.US_EAST_1)
@@ -24,7 +25,8 @@ class DynamoDbConfig {
     
     @Bean
     @Singleton
-    fun dynamoDbEnhancedClient(dynamoDbClient: DynamoDbClient): DynamoDbEnhancedClient {
+    @MedicationCatalogDynamoDb
+    fun dynamoDbEnhancedClient(@MedicationCatalogDynamoDb dynamoDbClient: DynamoDbClient): DynamoDbEnhancedClient {
         return DynamoDbEnhancedClient.builder()
             .dynamoDbClient(dynamoDbClient)
             .build()

--- a/src/main/kotlin/com/healthcare/medication/catalog/infrastructure/config/MedicationCatalogDynamoDb.kt
+++ b/src/main/kotlin/com/healthcare/medication/catalog/infrastructure/config/MedicationCatalogDynamoDb.kt
@@ -1,0 +1,8 @@
+package com.healthcare.medication.catalog.infrastructure.config
+
+import jakarta.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FIELD, AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER, AnnotationTarget.CLASS)
+annotation class MedicationCatalogDynamoDb

--- a/src/main/kotlin/com/healthcare/medication/catalog/infrastructure/dynamodb/MedicationCatalogRepositoryImpl.kt
+++ b/src/main/kotlin/com/healthcare/medication/catalog/infrastructure/dynamodb/MedicationCatalogRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.healthcare.medication.catalog.domain.model.MedicationCatalog
 import com.healthcare.medication.catalog.domain.model.MedicationCategory
 import com.healthcare.medication.catalog.domain.model.valueobjects.MedicationName
 import com.healthcare.medication.catalog.domain.repository.MedicationCatalogRepository
+import com.healthcare.medication.catalog.infrastructure.config.MedicationCatalogDynamoDb
 import io.micronaut.context.annotation.Requires
 import jakarta.inject.Singleton
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient
@@ -15,7 +16,7 @@ import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional
 @Singleton
 @Requires(notEnv = ["test"])
 class MedicationCatalogRepositoryImpl(
-    private val enhancedClient: DynamoDbEnhancedClient
+    @MedicationCatalogDynamoDb private val enhancedClient: DynamoDbEnhancedClient
 ) : MedicationCatalogRepository {
     
     private val table: DynamoDbTable<MedicationCatalogEntity> = enhancedClient.table(


### PR DESCRIPTION
## Summary
- Add `@MedicationCatalogDynamoDb` qualifier annotation to prevent bean conflicts when multiple microservices run simultaneously
- Apply service-specific qualifiers to `DynamoDbClient` and `DynamoDbEnhancedClient` beans
- Update `MedicationCatalogRepositoryImpl` to use qualified dependency injection

## Problem Solved
Previously, running multiple healthcare microservices simultaneously resulted in:
```
Multiple possible bean candidates found: [DynamoDbClient, DynamoDbClient]
```

This occurred because each service created generic DynamoDB beans without qualifiers, causing Micronaut's dependency injection to fail when multiple services were loaded in the same environment.

## Solution
1. **Created custom qualifier**: `@MedicationCatalogDynamoDb` annotation
2. **Qualified DynamoDB beans**: Applied qualifiers to both client beans in `DynamoDbConfig`
3. **Updated injection**: Repository now injects `@MedicationCatalogDynamoDb`-qualified client

## Test plan
- [x] Service starts successfully on port 8081
- [x] Can run alongside patient-management-service without conflicts
- [x] All existing functionality preserved
- [x] DynamoDB operations work correctly with qualified beans

## Impact
- ✅ Multiple microservices can now run simultaneously
- ✅ Shared DynamoDB Local instance works across services
- ✅ No breaking changes to existing functionality
- ✅ Follows healthcare microservices architecture standards

🤖 Generated with [Claude Code](https://claude.ai/code)